### PR TITLE
Make use of an AntPathMatcher to make checking on paths more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Add the following dependency to your POM.
 <dependency>
     <groupId>be.tomcools</groupId>
     <artifactId>rickroll-security-spring-boot-starter</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 </dependency>
 ```
 
 Paths you want to redirect can be configured in your Spring Application Properties:
 
 ```
-rickroll.paths=/admin,/tomcools
+rickroll.paths=/admin,/tomcools,/**/bye-bye/*
 rickroll.file-extensions=php
 ```
 
@@ -46,7 +46,10 @@ Available versions:
 | VERSION_NAME  | URL                                          |
 |---------------|----------------------------------------------|
 | original      | https://www.youtube.com/watch?v=dQw4w9WgXcQ  |
-| scary-pockets | https://www.youtube.com/watch?v=sQnoZUR6fvY" |
+| scary-pockets | https://www.youtube.com/watch?v=sQnoZUR6fvY |
+
+Since version 1.3.0, it's possible to use patterns as path configurations. Patterns give more flexibility and help to reduce the total amount of configured paths.  
+Request URIs will be checked on a match using an [`AntPathMatcher`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html).
 
 ## FAQ
 
@@ -54,12 +57,12 @@ Available versions:
 
 Why don't you try that for yourself? #evillaugh
 
-The implementation is based on a Filter.class. So anything that happens after the filter will be replaced by some nice music.
+The implementation is based on a `Filter.class`. So anything that happens after the filter will be replaced by some nice music.
 In case of a RestController, since this comes after the Filter...you will be rickroll'd.
 
 ### Why did you hardcode the Rickroll URL?
 Let's face it. That video will only be removed from the internet in case of an apocalyptic event. In which case, this project won't matter much either.
-We are allowing PR's to add alternative URLs. These will be validated by us before being added to available options.
+We are allowing PRs to add alternative URLs. These will be validated by us before being added to available options.
 
 
 ## Special Thanks

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>be.tomcools</groupId>
     <artifactId>rickroll-security-spring-boot-starter</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>rickroll-security-spring-boot-starter</name>
     <description>Redirects common security endpoints to Rick Astley - Never Gonna Give You Up</description>
 

--- a/src/main/java/be/tomcools/rickrollsecurity/RickRollFilter.java
+++ b/src/main/java/be/tomcools/rickrollsecurity/RickRollFilter.java
@@ -1,5 +1,8 @@
 package be.tomcools.rickrollsecurity;
 
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -10,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class RickRollFilter implements Filter {
+    private static final PathMatcher PATH_MATCHER = new AntPathMatcher();
 
     private final RickRollConfigurationProperties properties;
 
@@ -23,7 +27,7 @@ public class RickRollFilter implements Filter {
         HttpServletResponse response = (HttpServletResponse) servletResponse;
         String requestUri = request.getRequestURI();
         for (String path : properties.getPaths()) {
-            if (requestUri.equals(path)) {
+            if (PATH_MATCHER.match(path, requestUri)) {
                 rickroll(response);
                 return;
             }

--- a/src/test/java/be/tomcools/rickrollsecurity/RickrollSecuritySpringBootStarterApplicationTests.java
+++ b/src/test/java/be/tomcools/rickrollsecurity/RickrollSecuritySpringBootStarterApplicationTests.java
@@ -1,23 +1,15 @@
 package be.tomcools.rickrollsecurity;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @TestPropertySource(locations = "classpath:test.properties")
 @SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -30,6 +22,18 @@ class RickrollSecuritySpringBootStarterApplicationTests {
     void testRedirectForPath() {
         ResponseEntity<String> forEntity = template.getForEntity("/admin", String.class);
         assertThat(forEntity.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    }
+
+    @Test
+    void testRedirectForPathMatch() {
+        ResponseEntity<String> forEntity = template.getForEntity("/admin/rick-roll", String.class);
+        assertThat(forEntity.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    }
+
+    @Test
+    void testRedirectForSubPathNoMatch() {
+        ResponseEntity<String> forEntity = template.getForEntity("/rick-roll/admin", String.class);
+        assertThat(forEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,2 +1,2 @@
-rickroll.paths=/admin
+rickroll.paths=/admin,/admin/**
 rickroll.file-extensions=php


### PR DESCRIPTION
This is a PR for https://github.com/TomCools/rickroll-security-spring-boot-starter/issues/2. By using an `AntPathMatcher` you can now use patterns to add more flexibility in matching a configured path pattern to the request URI. This makes is easier to match on path segments.

I noticed this code is based on Spring Boot 2.3.0, but also works just fine with version 2.4.3.