### PR TITLE
No need to install the project in a Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,5 @@
 # and commit this file to your remote git repository to share the goodness with others.
 
 tasks:
-  - init: mvn install -DskipTests=false
-
+  - init: mvn verify
 


### PR DESCRIPTION
Installing should only be necessary if you have another project in your development
environment that depends on this project. I don't think that's going to be the case
in Gitpod environments.

Please see https://github.com/aalmiray/mvn-clean-install for related memes.