### PR TITLE
Update RickRollFilter

### DIFF
--- a/src/main/java/be/tomcools/rickrollsecurity/RickRollFilter.java
+++ b/src/main/java/be/tomcools/rickrollsecurity/RickRollFilter.java
@@ -1,5 +1,6 @@
 package be.tomcools.rickrollsecurity;
 
+import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
 
@@ -12,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Component
 public class RickRollFilter implements Filter {
     private static final PathMatcher PATH_MATCHER = new AntPathMatcher();
 


### PR DESCRIPTION
Uw filter class heeft geen @Component annotatie, waardoor deze niet automatisch wordt gebruikt. Het is onduidelijk of dit veroorzaakt is door een Spring Boot update of dat het simpelweg vergeten is.